### PR TITLE
Adds a bot whitelisting feature into the Owner cog

### DIFF
--- a/red.py
+++ b/red.py
@@ -143,7 +143,8 @@ class Bot(commands.Bot):
     def user_allowed(self, message):
         author = message.author
 
-        if author.bot:
+        bot_whitelist = self.get_cog('Owner').bot_whitelist
+        if author.bot and author.id not in bot_whitelist:
             return False
 
         if author == self.user:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
- Allows whitelisting bots to be able to trigger Red
- Bot whitelist is stored in `data/red/bot_whitelist.json`
- Manually tested